### PR TITLE
Add PHP install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Homygo App
+
+This repository contains the source for the Homygo web application.
+
+## PHP setup
+
+To install PHP and required dependencies locally, run:
+
+```bash
+./scripts/install-php.sh
+```
+
+This installs `php`, `php-cli`, `php-fpm`, `php-curl`, `php-mbstring`, and `php-xml` using `apt-get`.

--- a/scripts/install-php.sh
+++ b/scripts/install-php.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+sudo apt-get update -y
+sudo apt-get install -y \
+  php php-cli php-fpm \
+  php-curl php-mbstring php-xml


### PR DESCRIPTION
## Summary
- clarify PHP install steps and include extra extensions

## Testing
- `php -v`


------
https://chatgpt.com/codex/tasks/task_e_68518d26ed14832d827a2827071b92f1